### PR TITLE
Incorrect field name

### DIFF
--- a/error.md
+++ b/error.md
@@ -17,7 +17,7 @@ Imagine we have the following validation errors:
 The most basic usage of the `error` component exists in using it as a self-closing component with a `field` attribute:
 
 ```html
-<x-error field="email" class="text-red-500" />
+<x-error field="first_name" class="text-red-500" />
 ```
 
 This will output the following HTML:


### PR DESCRIPTION
I think the email field should be replaced by 'first_name'. Am I right?
Thank you for this nice repo.

<!--
Please only send a pull request to the latest release branch.

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; etc.

If applicable, also send a PR to the docs for the new change you're submitting.
-->
