### PR TITLE
Added configuration setup to mapbox

### DIFF
--- a/mapbox.md
+++ b/mapbox.md
@@ -9,9 +9,7 @@ While the `mapbox` component works out-of-the-box when you've [set the directive
 - [Alpine.js](https://github.com/alpinejs/alpine) `^2.3`
 - [Mapbox](https://docs.mapbox.com/mapbox-gl-js/api/) `^1.8`
 
-## Configuration
-
-To set up the API access token for Mapbox. you will need to add a configuration option to your config/services.php configuration file:
+To set up the API access token for Mapbox you will need to add a config option to your `config/services.php` file:
 
 ```php
 'mapbox' => [
@@ -19,7 +17,7 @@ To set up the API access token for Mapbox. you will need to add a configuration 
 ],
 ```
 
-Get your Mapbox access key from the [dashboard](https://account.mapbox.com/) after creating an app with them. Then set it in your .env file:
+Get your Mapbox access key from the [dashboard](https://account.mapbox.com) after creating an app with them. Then set it in your .env file:
 
 ```
 MAPBOX_PUBLIC_TOKEN=<your access key>

--- a/mapbox.md
+++ b/mapbox.md
@@ -9,6 +9,16 @@ While the `mapbox` component works out-of-the-box when you've [set the directive
 - [Alpine.js](https://github.com/alpinejs/alpine) `^2.3`
 - [Mapbox](https://docs.mapbox.com/mapbox-gl-js/api/) `^1.8`
 
+## Configuration
+
+To set up the API access token for Mapbox. you will need to add a configuration option to your config/services.php configuration file:
+
+```php
+'mapbox' => [
+    'public_token' => env('MAPBOX_PUBLIC_TOKEN'),
+],
+```
+
 ## Basic Usage
 
 In its most basic usage, you use it as a self closing component:

--- a/mapbox.md
+++ b/mapbox.md
@@ -19,6 +19,12 @@ To set up the API access token for Mapbox. you will need to add a configuration 
 ],
 ```
 
+Get your Mapbox access key from the [dashboard](https://account.mapbox.com/) after creating an app with them. Then set it in your .env file:
+
+```
+MAPBOX_PUBLIC_TOKEN=<your access key>
+```
+
 ## Basic Usage
 
 In its most basic usage, you use it as a self closing component:


### PR DESCRIPTION
Added configuration setup to make it clear that you should set up the public_token in services config.

I have seen some users having a hard time configuring API token for component. Not knowing how it should be configured. So thought of adding this part to mapbox component to make things clear.